### PR TITLE
explore view model fix 

### DIFF
--- a/app/src/main/java/com/example/agora/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/agora/screens/explore/ExploreViewModel.kt
@@ -24,7 +24,7 @@ class ExploreViewModel : ViewModel() {
 //        Post(title="Fridge 2", price=100.12),
 //        Post(title="Fridge 3", price=121.00)
 //    )
-//    private val titles2 = lis tOf(
+//    private val titles2 = listOf(
 //        Post(title="Book", price=7.99),
 //        Post(title="Book 2", price=9.50),
 //        Post(title="Book 3", price=10.25)


### PR DESCRIPTION
I changed the categories to an actual enum string, breaking the explore page since they are sectioned off by numbers 1 to 4.
Temporary fix to grab the string enum and map it to a number to unblock dev

![image](https://github.com/user-attachments/assets/11c54227-ead5-4eeb-9b5a-ec9c0a12a522)


